### PR TITLE
Update Part 2 Forward Propagation.ipynb

### DIFF
--- a/Part 2 Forward Propagation.ipynb
+++ b/Part 2 Forward Propagation.ipynb
@@ -56,9 +56,9 @@
     "|y |$$y$$|target data|(numExamples, outputLayerSize)|\n",
     "|W1 | $$W^{(1)}$$ | Layer 1 weights | (inputLayerSize, hiddenLayerSize) |\n",
     "|W2 | $$W^{(2)}$$ | Layer 2 weights | (hiddenLayerSize, outputLayerSize) |\n",
-    "|z2 | $$z^{(2)}$$ | Layer 2 activation | (numExamples, hiddenLayerSize) |\n",
-    "|a2 | $$a^{(2)}$$ | Layer 2 activity | (numExamples, hiddenLayerSize) |\n",
-    "|z3 | $$z^{(3)}$$ | Layer 3 activation | (numExamples, outputLayerSize) |"
+    "|z2 | $$a^{(2)}$$ | Layer 2 activation | (numExamples, hiddenLayerSize) |\n",
+    "|a2 | $$z^{(2)}$$ | Layer 2 activity | (numExamples, hiddenLayerSize) |\n",
+    "|z3 | $$a^{(3)}$$ | Layer 3 activation | (numExamples, outputLayerSize) |"
    ]
   },
   {


### PR DESCRIPTION
The notation for a -> activation and z -> activity, was inverted.