### PR TITLE
Update Part 2 Forward Propagation.ipynb

### DIFF
--- a/Part 2 Forward Propagation.ipynb
+++ b/Part 2 Forward Propagation.ipynb
@@ -56,9 +56,9 @@
     "|y |$$y$$|target data|(numExamples, outputLayerSize)|\n",
     "|W1 | $$W^{(1)}$$ | Layer 1 weights | (inputLayerSize, hiddenLayerSize) |\n",
     "|W2 | $$W^{(2)}$$ | Layer 2 weights | (hiddenLayerSize, outputLayerSize) |\n",
-    "|z2 | $$z^{(2)}$$ | Layer 2 activation | (numExamples, hiddenLayerSize) |\n",
-    "|a2 | $$a^{(2)}$$ | Layer 2 activity | (numExamples, hiddenLayerSize) |\n",
-    "|z3 | $$z^{(3)}$$ | Layer 3 activation | (numExamples, outputLayerSize) |"
+    "|z2 | $$z^{(2)}$$ | Layer 2 activity | (numExamples, hiddenLayerSize) |\n",
+    "|a2 | $$a^{(2)}$$ | Layer 2 activation | (numExamples, hiddenLayerSize) |\n",
+    "|z3 | $$z^{(3)}$$ | Layer 3 activity | (numExamples, outputLayerSize) |"
    ]
   },
   {


### PR DESCRIPTION
The definitions were inversed (z -> activity, a -> activation)